### PR TITLE
Ugly cars list

### DIFF
--- a/ugly cars
+++ b/ugly cars
@@ -1,0 +1,1 @@
+Ugliest cars list


### PR DESCRIPTION
100. 2010 Porsche Panamera: Number 67 on Edmunds.com's list of the "100 Greatest Cars of All Time." But while the roof line may provide decent headroom, it makes the car a misshapen hunchback.

99. 2010 Toyota Prius: The polliwog of green piety. Efficiency reduced down to the point of ennui.

98. 2001 Chrysler PT Cruiser: Styling cues of the '40s shoveled atop the proportions of a front-drive station wagon. Retro done wrong.

97. 2011 Nissan Leaf: Advanced all-electric car cleverly disguised as a bubble gum bubble with door handles. The future has to be more interesting than this.

96. 1959 Buick Electra 225: All the 1950s styling clichés fight each other to the death on a relentlessly tasteless car. You could slice ham with those tail fins.

95. 1973 Austin Allegro: So weird it could have been French. But no, it was British Leyland's most awkward shape. Today it's an icon of English decline. It had a square steering wheel!

94. 1959 Ford Anglia: Everything that was wrong with American styling of the late-1950s is even worse on a tiny British Ford. The roof line seems to die of embarrassment at the rear window.

93. 1990 Chrysler Imperial: The once glorious Imperial name is slapped on a stretched, front-drive K-car chassis and then stuck with a ridiculous nose. A car that begged to be abandoned in the desert even before its lease was up.

92. 1975 Ford Granada: Hideous imitation Mercedes atop an old, disposable Falcon chassis. It was clumsy in every way. Despite its huge sales then, it's an obscurity today.

91. 1957 Trabant: When East Germany wasn't busy screwing up everything else, it forced its citizens to buy this rattling bucket of ugly misery. Styled so that no two body panels ever aligned with each other.

100 Ugliest Cars

90. 1958 Ford Thunderbird: The classy and classic two-seater devolves into this bizarre four-seater that sells enormously well. At practically the same moment the Soviet Union launched Sputnik, America launched this atrocity.

89. 1990 Chrysler LeBaron Landau: Derived from the K-car, it's the Plymouth Acclaim with a stupid grille and ridiculous vinyl half-roof that made the rear window smaller.

88. 1973 Oldsmobile Omega: It's the Chevy Nova uglified with a split waterfall grille. Unnecessary, unloved and unattractive, the Omega indicated the contempt GM had for its own customers.

87. 1959 Ford Fairlane: The sort-of-pretty '57 Ford disintegrates under the weight of a flat nose, dopey fins and a dorky roof. It was a Kleenex box on tiny whitewalls.

86. 2007 Jeep Compass: The evil idea of basing a Jeep on a front-drive chassis becomes an utterly heinous and wimpy reality. Ill-proportioned, absurdly detailed and cheap-looking, too; it makes the similarly conceived Patriot look almost rugged.

85. 1977 Dodge Charger: The once muscular and exciting Charger is issued a double-knit leisure suit and ordered to battle Chevy's Monte Carlo. Why didn't Chrysler just announce that it wanted to go bankrupt?

84. 1961 Checker Marathon: Brutally bulky and achingly archaic, the Marathon's sheer ruggedness and utility made it a legendary cab. Sometimes ugly doesn't matter.

83. 1986 Hyundai Excel: Hyundai enters the U.S. market with a haphazard collection of cast-off Mitsubishi parts in a $4,995 plain nasty wrapper. Who knew what success would come?

82. 1977 Chrysler LeBaron: Chrysler takes the disastrously poorly made Plymouth Volare and absurdly pads it for luxury duty. Hey, the headlights are on upside-down!

81. 1971 Mercury Cougar: The once nimble Cougar bloats up into an over-styled mess. Massive rear bumper threatened to consume the planet's entire supply of chrome.

100 Ugliest Cars

80. 1976 Jaguar XJ-S: Successor to the lovely E-Type, the XJ-S is Jag's version of the Chevrolet Monte Carlo. Massive flying buttress roof concludes in huge taillights that together look like red plastic salad tongs.

79. 1965 Rambler Marlin: To move upmarket, AMC takes the boring American and adds a tapered fastback roof to produce a car that can only be called "dorky."

78. 2013 GMC Terrain Denali: The brick-shaped Terrain was awful. Covering it in shiny plastic to create the Denali edition only makes it worse. Design by building block.

77. 1972 Ford Thunderbird: A full 214 inches of utterly goofy sheet metal. The mega-bird was basically the Lincoln Mark IV drained of any style.

76. 1986 Cadillac Eldorado: The dwarf-spec generation of Cadillac's once glorious front-drive coupe. Even pimps couldn't pimp it out.

75. 1959 Oldsmobile Dynamic 88: Every square inch more bizarre than the square inch next to it. Yes it was extravagantly tasteless, but somehow dull and forlorn, too.

74. 2009 Nissan Cube: Determined to be cute, it turns out to just be weird and affected. And weirdly affected, too.

73. 2006 Subaru B9 Tribeca: Subaru's legendary oddness, swollen up in size and then cursed by a Venusian nose and a Martian tail.

72. 1980 Oldsmobile Omega: All of GM's X-car front-drivers were awful in their own special way. The Omega mixed a ridiculous grille with a dumpy body. It announced its awfulness.

71. 1978 Volvo 262C: Volvo has Italy's Bertone squash the roof of the six-cylinder 260-series. The result is laughably unstylish and hopelessly boxy.

100 Ugliest Cars

70. 1971 Plymouth Cricket: Britain's dowdy Hillman Avenger gets a new grille and whitewalls for America. It was ugly in the least interesting way possible.

69. 1958 Lincoln Continental: Relentlessly over-styled from its massive and winged front bumper, slanted and stacked headlights, speared and scalloped flanks and overhanging roof. Hideous.

68. 1982 Chrysler LeBaron: It's the K-car eye-fried in formal grille, dopey vinyl roof and two-tone paint. At least the original K didn't pretend to be anything except ordinary.

67. 1975 AMC Pacer: The legendary fishbowl of Loserland. It was too wide, too short and agonizingly bulbous.

66. 2000 Hyundai Tiburon: Hyundai's march to respectability is sidetracked by the over-sculpted second-generation Tiburon coupe. Styled like gum stuck to the bottom of your boot.

65. 1983 Chrysler Executive Limousine: It's true. At some point someone inside Chrysler thought it was a good idea to build a stretched K-car limousine. They were wrong.

64. 1965 Renault 16: Everything a weird French car should be, including arbitrarily sculpted and awkwardly perched atop skinny tires.

63. 2011 Nissan Juke: It has at least six headlights and fenders that seem tacked on as an afterthought. It's proudly peculiar and un-pretty.

62. 2004 Chevrolet Malibu Maxx: Half-hearted effort at a long-wheelbase station wagon that wound up looking like a stack of saltines.

61. 1974 Bricklin SV-1: A wavy, thick fiberglass body with gullwing doors that never closed tightly. Looked like it was falling apart even as it was being assembled.

100 Ugliest Cars

60. 1991 Chevrolet Caprice: A marine mammal stuck on four wheels. Redeemed only slightly when it was given a more powerful V8 as the 1994 Impala SS.

59. 1996 Ford Taurus: Based on ovals, this redesign was so disastrously lousy that it practically killed the Taurus altogether. The car you hated to rent.

58. 2000 Chevrolet Monte Carlo: A car whose skin seemed to be melting off of it. It featured a cacophony of styling cues fighting for attention. NASCAR-themed special editions only made it look worse.

57. 1992 Buick Skylark: A strange attempt to marry a wedge-shaped grille with a standard economy car. GS models included hideous lower body molding.

56. 1989 Chevrolet Corsica Hatchback: A fifth door awkwardly grafted onto the existing and boring midsize sedan. Think of it as Boris Karloff's head planted atop Bela Lugosi's body.

55. 2012 Mitsubishi i-MiEV: An egg that can't be cracked open and scrambled for breakfast. Exactly the misery module we feared we'd end up driving in the future.

54. 1974 AMC Matador Coupe: Flabby and goggle-eyed attempt to breathe life into AMC's midsize car. Its one saving grace was that it looked good racing in NASCAR.

53. 1957 Rambler Cross Country: Always the car for nerds who wanted the world to know they were nerds. It got psychedelic when haphazardly converted to a wagon.

52. 1956 Nash Ambassador Super: At the height of the Cold War, this was an American car so bizarre it could have been Russian. It was undiplomatically awful-looking.

51. 1949 Airway: Rear-engine, 10-horsepower obscurity with the tiniest wheels ever put on a road car. Basically it was a go-cart with an aluminum body.

100 Ugliest Cars

50. 1980 Cadillac Seville: A misbegotten attempt to revive the styling themes of the 1930s. Ugliest trunk lid around until Chris Bangle started working for BMW.

49. 1978 Oldsmobile Cutlass: Four-door fastback styling on a car no one wanted to see become a fastback. It looked stupid and sold in disastrously small numbers.

48. 1973 Datsun B-210: What a truly cheap car looked like in the 1970s. Late versions with big bumpers were particularly heinous.

47. 1982 Cadillac Cimarron: A Chevy Cavalier tarted up to pass as a BMW competitor. Laughably stupid-looking, it somehow stayed in production for seven years.

46. 1980 Ford Thunderbird: Tragic attempt to apply big car styling to a downsized, boxy coupe. Actual boxes weren't as boxy as this foul fowl.

45. 2010 BMW 5 Series GT: Oversize five-door that besmirches the 5 Series' legacy with a dopey, high-riding tail. If BMW has lost its way, it's cars like this that are leading it astray.

44. 1961 Plymouth Valiant: Every excessive and geeky styling mistake of bigger, early 1960s Chrysler products in a more compact and convenient size.

43. 1986 Pontiac Grand Prix 2+2: Built to race in NASCAR, it featured a silly pointed prow up front and a huge rear window. It was ugly and it didn't win much either.

42. 2008 BMW X6: Think of it as an X5 with a fastback roof and without all that pesky utility. It looks like a Bavarian cockroach.

41. 1974 Ford Mustang II: Every traditional Mustang styling cue exaggerated to the point of visual agony. It's the one Mustang worthy of contempt.

100 Ugliest Cars

40. 1961 Renault 4: Think of it as the 2CV without the charm, whimsy or promise of simplicity. It was a willfully obtuse design that remained in production for 32 years.

39. 1959 Dodge Coronet: Every surface on the car seems to be headed in a different direction. The big-mouth grille seems ready to suck in all the ocean's plankton.

38. 1996 Suzuki X90: The only vehicle ever built that looks better with a giant can of Red Bull bolted atop it.

37. 2002 Lexus SC 430: Turn a bathtub upside-down, cut a chunk out of its floor to make it a convertible, install a Lexus powertrain and, voilà, you have the SC 430.

36. 1970 AMC Gremlin: Desperate for a small car, AMC chops up the Hornet compact and creates the Gremlin. Pure butchery that looks like it was done with a rusty cleaver.

35. 1980 Lincoln Mark VI: The shrunken Mark VI two-door was hideous, but the four-door sedan was hideous and atrocious. Every bad idea Ford ever had about styling in one car.

34. 2003 Saturn Ion Sedan: Apparently designed by jumping into a pile of Legos and seeing which pieces stuck together. And yet it was strangely generic and anonymous, too.

33. 1985 Pontiac Grand Am: Pontiac's shrunken-head coupe and sedan were covered in cheesy plastic cladding. It was the beginning of the end.

32. 1961 Citroen Ami: It embodies utter aesthetic aggression. It dares buyers not to love it. It is, in other words, the quintessential French car.

31. 1957 Mercury Turnpike Cruiser: It features a ridiculous front bumper, radio antennas shooting forward from the roof, silly side trim and a rear window that goes down. What's not to love/hate?

100 Ugliest Cars

30. 1958 Subaru 360: It looks sort of like concrete that's been left to harden in a wheelbarrow, only less comfortable.

29. 1947 Davis D-2 Divan: Ludicrous three-wheeler that featured four-across seating. Mercifully, the company went out of business just as production was ramping up.

28. 1985 Oldsmobile Calais: Malevolently ill-proportioned, the Calais was the ugliest of the GM N-platform stepsisters. It was a car for buyers who had given up on living.

27. 1959 Daimler SP250: British sports cars are supposed to be eccentric and this one is eccentric in five-dozen ways. Its fish-lips grille is at war with the sparrow hawk tail fins.

26. 1948 Citroen 2CV: Yes, the deux chevaux is a ramshackle assembly of corrugated tin. It's ugly in all the best ways possible. And sometimes, ugly is perfect.

25. 1982 Lincoln Continental: The Continental tumbles down onto Ford's pedestrian Fox platform and gets stuck with the 1980 Seville's styling.

24. 2004 Kia Amanti: Bolt upright and almost silly in its formality. The grille looks like a sewer grate. Any stranger and it would be North Korean.

23. 1971 Subaru Leone: There are more comfortable-looking riding lawnmowers. It's positively agricultural.

22. 1978 Subaru BRAT: Whimsical name for a strange pickup built off the Leone. It's the sort of car that announces your economic marginalization.

21. 1974 AMC Matador: To deal with new bumper regulations, AMC puts a big schnoz on the once-innocuous Matador sedan. Even cops were embarrassed to drive them.

100 Ugliest Cars

20. 2010 Lincoln MKT: Thick-hipped, big-nosed and oddly misshapen. A Lincoln station wagon straining to be taken for a crossover... and no one cares.

19. 1974 Ford Torino Elite: Desperate attempt to compete with Chevy's Monte Carlo. It's really a Mercury Cougar with a vast and ugly nose.

18. 1958 Packard Hawk: Unwilling to let Packard die a dignified death, its name is slapped onto a particularly awful version of the Studebaker Hawk. Inexcusable.

17. 1976 Aston Martin Lagonda: Styled by William Townes apparently using a single straight edge and a box cutter. Crude modernism.

16. 2009 Ferrari California: Over-styled and butt-heavy, it's the least Ferrari-like of all Ferraris. A soft-bodied cruiser from an otherwise hard-core builder.

15. 1956 Tatra 603: It's yet one more communist atrocity. This Czechoslovakian freak used a rear-mounted, air-cooled V8, which helps explain the ridiculous appearance. But it doesn't excuse it.

14. 1961 Dodge Dart: The big Dodges for '61 get concave grilles and overwrought front fenders to go with their goofball tail fins.

13. 1961 Plymouth Fury: Even worse than the '61 Dodges were the '61 Plymouths with a front end that looked literally insane.

12. 1960 Plymouth Fury: The '59 Caddy had the biggest fins, but it was the '60 Fury that had the ugliest. Not that the front end was tolerable, either.

11. 1976 Rolls-Royce Camargue: Pininfarina proves that with a little provocation it can design a clumsy and ridiculous coupe. It's a Rolls-Royce that looks like a Fiat.

100 Ugliest Cars

10. 2002 BMW 7 Series: Chris Bangle bungles BMW's flagship sedan with a complex front end and a hideous tail bump trunk lid. It's a first-order screw-up.

9. 1976 Bristol Blenheim: What a 13-year-old British schoolboy would draw in study hall. That is, if he weren't very bright and couldn't really draw.

8. 1958 Edsel: As a car it was no worse than a Ford or Mercury. But it was so hideous that the market rejected it and it's been synonymous with failure ever since.

7. 1974 Datsun F10: Nissan worked hard to make sure each component on this disaster was as ugly as possible. And then it turned out to be even worse-looking than the sum of all its parts.

6. 1998 Fiat Multipla: It looks as if it escaped from Neptune, bounced around the solar system hitting asteroids, and then melted while entering the Earth's atmosphere.

5. 2001 Pontiac Aztek: A good idea ruined when forced onto a minivan chassis. If there are any executives left at GM who signed off on this, there is no justice in the universe.

4. 1985 Cadillac Deville: Squashed, squared and indistinguishable from an Olds or Buick. This is the car that announced GM didn't care about Cadillac anymore.

3. 2010 Acura ZDX: Insanity manifested as a spacey-looking five-door thingamajig. Utterly pointless and it looks it, too.

2. 1977 Lincoln Versailles: A rushed response to the original Cadillac Seville, it was a Ford Granada with a half-ass Continental kit. A 1979 face-lift changed the roof profile, but made the car even uglier.

1. 2014 Lamborghini Veneno: Every supercar cliché and every bad idea Lamborghini ever had, stuffed into one overpriced showcar. It's the worst thing out of Italy since fascism. Mercifully, only three will be made, which is still three too many.

